### PR TITLE
Fix faiss-node ESM import compatibility

### DIFF
--- a/src/memory/vectors.ts
+++ b/src/memory/vectors.ts
@@ -1,4 +1,5 @@
-import { IndexFlatL2 } from "faiss-node";
+import faissNode from "faiss-node";
+const { IndexFlatL2 } = faissNode;
 import Database from "better-sqlite3";
 import { randomUUID } from "crypto";
 import { EmbeddingProvider, SemanticMemory, MemorySearchResult, MemoryType } from "./types.js";
@@ -11,7 +12,7 @@ export interface VectorStoreOptions {
 
 export class VectorStore {
   private db: Database.Database;
-  private index: IndexFlatL2;
+  private index: InstanceType<typeof IndexFlatL2>;
   private embedder: EmbeddingProvider;
   private idMap: Map<number, string> = new Map(); // FAISS index -> memory ID
   private nextFaissId: number = 0;


### PR DESCRIPTION
## Summary
- Fixed `faiss-node` import that was failing with ESM named export error
- Changed from `import { IndexFlatL2 } from "faiss-node"` to default import with destructuring
- Updated type annotation to use `InstanceType<typeof IndexFlatL2>`

## Problem
Both `telegram` and `api` containers were crash-looping with:
```
SyntaxError: Named export 'IndexFlatL2' not found. The requested module 'faiss-node' is a CommonJS module
```

## Test plan
- [ ] Build passes
- [ ] Containers start successfully
- [ ] Telegram bot responds to messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)